### PR TITLE
Use Quay.io hosted image for fcrepo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - 'db:/var/lib/mysql'
   fcrepo:
     restart: 'unless-stopped'
-    image: 'fcrepo_dev:latest'
+    image: 'quay.io/upennlibraries/fcrepo_dev:latest'
     depends_on:
       - 'db'
     links:
@@ -27,7 +27,3 @@ services:
 volumes:
   fcrepo:
   db:
-
-
-
-


### PR DESCRIPTION
We have an automated build running for the fcrepo_dev image going on Quay. 🚢 

Do we want to continue to use the `fcrepo_dev` name for the image to distinguish the environment, or would we rather call the image `fcrepo` and rely on tags for environments? (Assuming that the `_dev` suffix is referring to environment in the first place!)